### PR TITLE
Add watcher args

### DIFF
--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -137,6 +137,26 @@ def test_watch(mocker):
     assert next(iter_) == {'r2'}
 
 
+def test_watch_watcher_args(mocker):
+    class FakeWatcher:
+        def __init__(self, path, arg1, arg2):
+            self._results = iter([
+                {arg1},
+                set(),
+                {arg2},
+                set(),
+            ])
+
+        def check(self):
+            return next(self._results)
+
+    args = ["ahoy", "borec"]
+
+    iter_ = watch('xxx', watcher_cls=FakeWatcher, watcher_args=args, debounce=5, normal_sleep=2, min_sleep=1)
+    assert next(iter_) == {args[0]}
+    assert next(iter_) == {args[1]}
+
+
 def test_watch_stop():
     class FakeWatcher:
         def __init__(self, path):

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -94,8 +94,8 @@ def test_python(tmpdir):
 def test_regexp(tmpdir):
     mktree(tmpdir, tree)
 
-    re_files = r"^.*(\.txt|\.js)$"
-    re_dirs = r"^(?:(?!recursive_dir).)*$"
+    re_files = r'^.*(\.txt|\.js)$'
+    re_dirs = r'^(?:(?!recursive_dir).)*$'
 
     watcher = RegExpWatcher(str(tmpdir), re_files, re_dirs)
     changes = watcher.check()

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -137,9 +137,9 @@ def test_watch(mocker):
     assert next(iter_) == {'r2'}
 
 
-def test_watch_watcher_args(mocker):
+def test_watch_watcher_kwargs(mocker):
     class FakeWatcher:
-        def __init__(self, path, arg1, arg2):
+        def __init__(self, path, arg1=None, arg2=None):
             self._results = iter([
                 {arg1},
                 set(),
@@ -150,11 +150,11 @@ def test_watch_watcher_args(mocker):
         def check(self):
             return next(self._results)
 
-    args = ["ahoy", "borec"]
+    kwargs = dict(arg1='foo', arg2='bar')
 
-    iter_ = watch('xxx', watcher_cls=FakeWatcher, watcher_args=args, debounce=5, normal_sleep=2, min_sleep=1)
-    assert next(iter_) == {args[0]}
-    assert next(iter_) == {args[1]}
+    iter_ = watch('xxx', watcher_cls=FakeWatcher, watcher_kwargs=kwargs, debounce=5, normal_sleep=2, min_sleep=1)
+    assert next(iter_) == {kwargs['arg1']}
+    assert next(iter_) == {kwargs['arg2']}
 
 
 def test_watch_stop():

--- a/watchgod/main.py
+++ b/watchgod/main.py
@@ -8,7 +8,8 @@ from functools import partial
 from multiprocessing import Process
 from pathlib import Path
 from time import time
-from typing import Any, Awaitable, Callable, Dict, Set, Tuple, Type, Union
+from typing import (Any, Awaitable, Callable, Dict, Optional, Sequence, Set,
+                    Tuple, Type, Union)
 
 from .watcher import AllWatcher, Change, DefaultWatcher, PythonWatcher
 
@@ -52,12 +53,13 @@ class awatch:
     3.5 doesn't support yield in coroutines so we need all this fluff. Yawwwwn.
     """
     __slots__ = (
-        '_loop', '_path', '_watcher_cls', '_debounce', '_min_sleep', '_stop_event', '_normal_sleep', '_w', 'lock',
+        '_loop', '_path', '_watcher_cls', '_watcher_args', '_debounce', '_min_sleep', '_stop_event', '_normal_sleep', '_w', 'lock',
         '_executor'
     )
 
     def __init__(self, path: Union[Path, str], *,
                  watcher_cls: Type[AllWatcher]=DefaultWatcher,
+                 watcher_args: Optional[Sequence]=None,
                  debounce=1600,
                  normal_sleep=400,
                  min_sleep=50,
@@ -67,6 +69,7 @@ class awatch:
         self._executor = ThreadPoolExecutor(max_workers=4)
         self._path = path
         self._watcher_cls = watcher_cls
+        self._watcher_args = watcher_args or []
         self._debounce = debounce
         self._normal_sleep = normal_sleep
         self._min_sleep = min_sleep
@@ -80,7 +83,7 @@ class awatch:
 
     async def __anext__(self):
         if not self._w:
-            self._w = await self.run_in_executor(self._watcher_cls, self._path)
+            self._w = await self.run_in_executor(self._watcher_cls, self._path, *self._watcher_args)
         check_time = 0
         changes = set()
         last_change = 0

--- a/watchgod/main.py
+++ b/watchgod/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import logging
 import os
 import signal
@@ -52,13 +53,13 @@ class awatch:
     3.5 doesn't support yield in coroutines so we need all this fluff. Yawwwwn.
     """
     __slots__ = (
-        '_loop', '_path', '_watcher_cls', '_watcher_args', '_debounce', '_min_sleep', '_stop_event', '_normal_sleep',
+        '_loop', '_path', '_watcher_cls', '_watcher_kwargs', '_debounce', '_min_sleep', '_stop_event', '_normal_sleep',
         '_w', 'lock', '_executor'
     )
 
     def __init__(self, path: Union[Path, str], *,
                  watcher_cls: Type[AllWatcher]=DefaultWatcher,
-                 watcher_args: Optional[Sequence]=None,
+                 watcher_kwargs: Optional[Dict[str, Any]]=None,
                  debounce=1600,
                  normal_sleep=400,
                  min_sleep=50,
@@ -68,7 +69,7 @@ class awatch:
         self._executor = ThreadPoolExecutor(max_workers=4)
         self._path = path
         self._watcher_cls = watcher_cls
-        self._watcher_args = watcher_args or []
+        self._watcher_kwargs = watcher_kwargs or dict()
         self._debounce = debounce
         self._normal_sleep = normal_sleep
         self._min_sleep = min_sleep
@@ -82,7 +83,8 @@ class awatch:
 
     async def __anext__(self):
         if not self._w:
-            self._w = await self.run_in_executor(self._watcher_cls, self._path, *self._watcher_args)
+            self._w = await self.run_in_executor(
+                functools.partial(self._watcher_cls, self._path, **self._watcher_kwargs))
         check_time = 0
         changes = set()
         last_change = 0

--- a/watchgod/main.py
+++ b/watchgod/main.py
@@ -8,8 +8,7 @@ from functools import partial
 from multiprocessing import Process
 from pathlib import Path
 from time import time
-from typing import (Any, Awaitable, Callable, Dict, Optional, Sequence, Set,
-                    Tuple, Type, Union)
+from typing import Any, Awaitable, Callable, Dict, Optional, Sequence, Set, Tuple, Type, Union
 
 from .watcher import AllWatcher, Change, DefaultWatcher, PythonWatcher
 

--- a/watchgod/main.py
+++ b/watchgod/main.py
@@ -53,8 +53,8 @@ class awatch:
     3.5 doesn't support yield in coroutines so we need all this fluff. Yawwwwn.
     """
     __slots__ = (
-        '_loop', '_path', '_watcher_cls', '_watcher_args', '_debounce', '_min_sleep', '_stop_event', '_normal_sleep', '_w', 'lock',
-        '_executor'
+        '_loop', '_path', '_watcher_cls', '_watcher_args', '_debounce', '_min_sleep', '_stop_event', '_normal_sleep',
+        '_w', 'lock', '_executor'
     )
 
     def __init__(self, path: Union[Path, str], *,

--- a/watchgod/main.py
+++ b/watchgod/main.py
@@ -9,7 +9,7 @@ from functools import partial
 from multiprocessing import Process
 from pathlib import Path
 from time import time
-from typing import Any, Awaitable, Callable, Dict, Optional, Sequence, Set, Tuple, Type, Union
+from typing import Any, Awaitable, Callable, Dict, Optional, Set, Tuple, Type, Union
 
 from .watcher import AllWatcher, Change, DefaultWatcher, PythonWatcher
 

--- a/watchgod/watcher.py
+++ b/watchgod/watcher.py
@@ -84,7 +84,7 @@ class RegExpWatcher(AllWatcher):
     def __init__(self, root_path, re_files=None, re_dirs=None):
         self.re_files = re.compile(re_files) if re_files is not None else re_files
         self.re_dirs = re.compile(re_dirs) if re_files is not None else re_dirs
-        super(RegExpWatcher, self).__init__(root_path)
+        super().__init__(root_path)
 
     def should_watch_file(self, entry):
         return self.re_files.match(entry.path)

--- a/watchgod/watcher.py
+++ b/watchgod/watcher.py
@@ -3,7 +3,7 @@ import os
 import re
 from enum import IntEnum
 
-__all__ = 'Change', 'AllWatcher', 'DefaultDirWatcher', 'DefaultWatcher', 'PythonWatcher'
+__all__ = 'Change', 'AllWatcher', 'DefaultDirWatcher', 'DefaultWatcher', 'PythonWatcher', 'RegExpWatcher'
 logger = logging.getLogger('watchgod.watcher')
 
 
@@ -78,3 +78,16 @@ class DefaultWatcher(DefaultDirWatcher):
 class PythonWatcher(DefaultDirWatcher):
     def should_watch_file(self, entry):
         return entry.name.endswith(('.py', '.pyx', '.pyd'))
+
+
+class RegExpWatcher(AllWatcher):
+    def __init__(self, root_path, re_files=None, re_dirs=None):
+        self.re_files = re.compile(re_files) if re_files is not None else re_files
+        self.re_dirs = re.compile(re_dirs) if re_files is not None else re_dirs
+        super(RegExpWatcher, self).__init__(root_path)
+
+    def should_watch_file(self, entry):
+        return self.re_files.match(entry.path)
+
+    def should_watch_dir(self, entry):
+        return self.re_dirs.match(entry.path)


### PR DESCRIPTION
This change provides the arguments to Watcher object in watch function.
For example, when I would like to define ignored directories instead of hard-coding them.

~~~python
class ImageWatcher(AllWatcher):
    re_img = re.compile(r".*(jpe?g|png|bmp)$", re.IGNORECASE)

    def __init__(self, root_path, ignore=None):
        self.ignore = ignore or []
        super(ImageWatcher, self).__init__(root_path)

    def should_watch_file(self, entry):
        return self.re_img.match(entry.path)

    def should_watch_dir(self, entry):
        return entry.name not in self.ignore


for changes in watch(".", watcher_cls=ImageWatcher, watcher_args=["ignore"]):
    print(changes)
~~~