### PR TITLE
Fix #32

### DIFF
--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -114,26 +114,59 @@ def test_regexp(tmpdir):
         (Change.added, str(tmpdir.join('foo/borec-js.js')))}
 
 
-def test_regexp_no_args(tmpdir):
+def test_regexp_no_re_dirs(tmpdir):
     mktree(tmpdir, tree)
 
     re_files = r'^.*(\.txt|\.js)$'
 
-    watcher = RegExpWatcher(str(tmpdir), re_files)
-    changes = watcher.check()
+    watcher_no_re_dirs = RegExpWatcher(str(tmpdir), re_files)
+    changes = watcher_no_re_dirs.check()
     assert changes == set()
 
     sleep(0.01)
     tmpdir.join('foo/spam.py').write('xxx')
     tmpdir.join('foo/bar.txt').write('change')
-    tmpdir.join('foo/foo.txt').write('ahoy')
-    tmpdir.join('foo/bar-js.js').write('peace')
-    tmpdir.join('foo/recursive_dir/foo.js').write('borec')
+    tmpdir.join('foo/recursive_dir/foo.js').write('change')
 
-    assert watcher.check() == {
+    assert watcher_no_re_dirs.check() == {
         (Change.modified, str(tmpdir.join('foo/bar.txt'))),
-        (Change.added, str(tmpdir.join('foo/foo.txt'))),
-        (Change.added, str(tmpdir.join('foo/bar-js.js'))),
+        (Change.added, str(tmpdir.join('foo/recursive_dir/foo.js')))}
+
+
+def test_regexp_no_re_files(tmpdir):
+    mktree(tmpdir, tree)
+
+    re_dirs = r'^(?:(?!recursive_dir).)*$'
+
+    watcher_no_re_files = RegExpWatcher(str(tmpdir), re_dirs=re_dirs)
+    changes = watcher_no_re_files.check()
+    assert changes == set()
+
+    sleep(0.01)
+    tmpdir.join('foo/spam.py').write('xxx')
+    tmpdir.join('foo/bar.txt').write('change')
+    tmpdir.join('foo/recursive_dir/foo.js').write('change')
+
+    assert watcher_no_re_files.check() == {
+        (Change.modified, str(tmpdir.join('foo/spam.py'))),
+        (Change.modified, str(tmpdir.join('foo/bar.txt')))}
+
+
+def test_regexp_no_args(tmpdir):
+    mktree(tmpdir, tree)
+
+    watcher_no_args = RegExpWatcher(str(tmpdir))
+    changes = watcher_no_args.check()
+    assert changes == set()
+
+    sleep(0.01)
+    tmpdir.join('foo/spam.py').write('xxx')
+    tmpdir.join('foo/bar.txt').write('change')
+    tmpdir.join('foo/recursive_dir/foo.js').write('change')
+
+    assert watcher_no_args.check() == {
+        (Change.modified, str(tmpdir.join('foo/spam.py'))),
+        (Change.modified, str(tmpdir.join('foo/bar.txt'))),
         (Change.added, str(tmpdir.join('foo/recursive_dir/foo.js')))}
 
 

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -114,6 +114,29 @@ def test_regexp(tmpdir):
         (Change.added, str(tmpdir.join('foo/borec-js.js')))}
 
 
+def test_regexp_no_args(tmpdir):
+    mktree(tmpdir, tree)
+
+    re_files = r'^.*(\.txt|\.js)$'
+
+    watcher = RegExpWatcher(str(tmpdir), re_files)
+    changes = watcher.check()
+    assert changes == set()
+
+    sleep(0.01)
+    tmpdir.join('foo/spam.py').write('xxx')
+    tmpdir.join('foo/bar.txt').write('change')
+    tmpdir.join('foo/foo.txt').write('ahoy')
+    tmpdir.join('foo/bar-js.js').write('peace')
+    tmpdir.join('foo/recursive_dir/foo.js').write('borec')
+
+    assert watcher.check() == {
+        (Change.modified, str(tmpdir.join('foo/bar.txt'))),
+        (Change.added, str(tmpdir.join('foo/foo.txt'))),
+        (Change.added, str(tmpdir.join('foo/bar-js.js'))),
+        (Change.added, str(tmpdir.join('foo/recursive_dir/foo.js')))}
+
+
 def test_does_not_exist(caplog):
     AllWatcher('/foo/bar')
     assert "error walking file system: FileNotFoundError [Errno 2] No such file or directory: '/foo/bar'" in caplog.text

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -111,7 +111,8 @@ def test_regexp(tmpdir):
     assert watcher.check() == {
         (Change.modified, str(tmpdir.join('foo/bar.txt'))),
         (Change.added, str(tmpdir.join('foo/borec.txt'))),
-        (Change.added, str(tmpdir.join('foo/borec-js.js')))}
+        (Change.added, str(tmpdir.join('foo/borec-js.js')))
+    }
 
 
 def test_regexp_no_re_dirs(tmpdir):
@@ -130,7 +131,8 @@ def test_regexp_no_re_dirs(tmpdir):
 
     assert watcher_no_re_dirs.check() == {
         (Change.modified, str(tmpdir.join('foo/bar.txt'))),
-        (Change.added, str(tmpdir.join('foo/recursive_dir/foo.js')))}
+        (Change.added, str(tmpdir.join('foo/recursive_dir/foo.js')))
+    }
 
 
 def test_regexp_no_re_files(tmpdir):
@@ -149,7 +151,8 @@ def test_regexp_no_re_files(tmpdir):
 
     assert watcher_no_re_files.check() == {
         (Change.modified, str(tmpdir.join('foo/spam.py'))),
-        (Change.modified, str(tmpdir.join('foo/bar.txt')))}
+        (Change.modified, str(tmpdir.join('foo/bar.txt')))
+    }
 
 
 def test_regexp_no_args(tmpdir):
@@ -167,7 +170,8 @@ def test_regexp_no_args(tmpdir):
     assert watcher_no_args.check() == {
         (Change.modified, str(tmpdir.join('foo/spam.py'))),
         (Change.modified, str(tmpdir.join('foo/bar.txt'))),
-        (Change.added, str(tmpdir.join('foo/recursive_dir/foo.js')))}
+        (Change.added, str(tmpdir.join('foo/recursive_dir/foo.js')))
+    }
 
 
 def test_does_not_exist(caplog):

--- a/watchgod/watcher.py
+++ b/watchgod/watcher.py
@@ -82,12 +82,10 @@ class PythonWatcher(DefaultDirWatcher):
 
 class RegExpWatcher(AllWatcher):
     def __init__(self, root_path, re_files=None, re_dirs=None):
-        self.re_files = re.compile(re_files) if re_files is not None else re_files
-        self.re_dirs = re.compile(re_dirs) if re_dirs is not None else re_dirs
+        if re_files is not None:
+            self.re_files = re.compile(re_files)
+            self.should_watch_file = lambda entry: self.re_files.match(entry.path)
+        if re_dirs is not None:
+            self.re_dirs = re.compile(re_dirs)
+            self.should_watch_dir = lambda entry: self.re_dirs.match(entry.path)
         super().__init__(root_path)
-
-    def should_watch_file(self, entry):
-        return self.re_files.match(entry.path)
-
-    def should_watch_dir(self, entry):
-        return self.re_dirs.match(entry.path)

--- a/watchgod/watcher.py
+++ b/watchgod/watcher.py
@@ -82,10 +82,18 @@ class PythonWatcher(DefaultDirWatcher):
 
 class RegExpWatcher(AllWatcher):
     def __init__(self, root_path, re_files=None, re_dirs=None):
-        if re_files is not None:
-            self.re_files = re.compile(re_files)
-            self.should_watch_file = lambda entry: self.re_files.match(entry.path)
-        if re_dirs is not None:
-            self.re_dirs = re.compile(re_dirs)
-            self.should_watch_dir = lambda entry: self.re_dirs.match(entry.path)
+        self.re_files = re.compile(re_files) if re_files is not None else re_files
+        self.re_dirs = re.compile(re_dirs) if re_dirs is not None else re_dirs
         super().__init__(root_path)
+
+    def should_watch_file(self, entry):
+        if self.re_files is not None:
+            return self.re_files.match(entry.path)
+        else:
+            return super().should_watch_file(entry)
+
+    def should_watch_dir(self, entry):
+        if self.re_dirs is not None:
+            return self.re_dirs.match(entry.path)
+        else:
+            return super().should_watch_dir(entry)


### PR DESCRIPTION
Make re_files and re_dirs arguments optional.
Use an inherited AllWatcher method if re_files or
re_dirs are not defined.

RegExpWatcher simply becomes AllWatcher If both re_files and re_dirs are not defined