### PR TITLE
WIP: Gracefully stop child processes

### DIFF
--- a/watchgod/main.py
+++ b/watchgod/main.py
@@ -187,5 +187,5 @@ async def arun_process(path: Union[Path, str], target: Callable, *,
         await watcher.run_in_executor(_stop_process, process)
         process = await watcher.run_in_executor(start_process)
         reloads += 1
-        await watcher.run_in_executor(_stop_process, process)
+    await watcher.run_in_executor(_stop_process, process)
     return reloads

--- a/watchgod/main.py
+++ b/watchgod/main.py
@@ -163,6 +163,7 @@ def run_process(path: Union[Path, str], target: Callable, *,
         _stop_process(process)
         process = _start_process(target=target, args=args, kwargs=kwargs)
         reloads += 1
+    _stop_process(process)
     return reloads
 
 
@@ -186,4 +187,5 @@ async def arun_process(path: Union[Path, str], target: Callable, *,
         await watcher.run_in_executor(_stop_process, process)
         process = await watcher.run_in_executor(start_process)
         reloads += 1
+        await watcher.run_in_executor(_stop_process, process)
     return reloads


### PR DESCRIPTION
Currently, Watchgod does not propagate signals to its children.

With this change, child processes will receive a SIGINT signal if Watchgod receives one.

This is still not a complete solution.
Watchgod currently only gracefully handles SIGINT but not SIGTERM.

Some sort of `loop.add_signal_handler(signal.SIGTERM, loop.stop)` should be implemented within the watch function.

I have not been able to write tests, but wanted to leave this PR as a starting point to more graceful signal handling.