### PR TITLE
add pep-561 marker file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     """,
     license='MIT',
     packages=['watchgod'],
+    package_data={'watchgod': ['py.typed']},
     python_requires='>=3.5',
     zip_safe=True,
 )

--- a/watchgod/py.typed
+++ b/watchgod/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561. The watchgod package uses inline types.


### PR DESCRIPTION
This PR adds [PEP 561](https://www.python.org/dev/peps/pep-0561/) support for `watchgod`. The rationale for this PR is that with the current 0.6 release, the type checks with `mypy` fail because `watchgod` doesn't report having type hints. To reproduce:

```sh
$ cat run.py  # the example from README
import asyncio
from watchgod.main import awatch

async def main() -> None:
   async for changes in awatch('/tmp'):
       print(changes)

asyncio.run(main())
$ pip install watchgod mypy
$ mypy run.py
run.py:2: error: Skipping analyzing 'watchgod.main': found module but no type hints or library stubs
run.py:2: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 1 source file)
```
The current workaround is to add the marker file manually:

```sh
$ touch $(python -c "import watchgod; print(watchgod.__path__[0])")/py.typed
$ mypy run.py
Success: no issues found in 1 source file
```