### PR TITLE
Make watchgod 10-100x faster

### DIFF
--- a/watchgod/watcher.py
+++ b/watchgod/watcher.py
@@ -27,12 +27,12 @@ class AllWatcher:
 
     def _walk(self, path, changes, new_files):
         if os.path.isfile(path):
-            self._watch_file(path, changes, new_files)
+            self._watch_file(path, changes, new_files, os.stat(path))
         else:
             self._walk_dir(path, changes, new_files)
 
-    def _watch_file(self, path, changes, new_files):
-        mtime = os.stat(path).st_mtime
+    def _watch_file(self, path, changes, new_files, stat):
+        mtime = stat.st_mtime
         new_files[path] = mtime
         old_mtime = self.files.get(path)
         if not old_mtime:
@@ -46,7 +46,7 @@ class AllWatcher:
                 if self.should_watch_dir(entry):
                     self._walk_dir(entry.path, changes, new_files)
             elif self.should_watch_file(entry):
-                self._watch_file(entry.path, changes, new_files)
+                self._watch_file(entry.path, changes, new_files, entry.stat())
 
     def check(self):
         changes = set()


### PR DESCRIPTION
I was considering watchgod for doing some file-watching and while reviewing the code I found one issue that I think is critical: watchgod is not taking full advantage of the `scandir` result!

Instead of doing a new `os.stat` for each file it should reuse what `scandir` already did (saving thousands of `stat` calls depending on the scenario).

I have some different targets, so, I won't be really use watchgod, but as I think this is really critical I decided to provide a pull request ;)