### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  precision: 2
+  range: [90, 100]
+  status:
+    patch: false
+    project: false
+
+comment:
+  layout: 'header, diff, flags, files, footer'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python-version: ['3.6', '3.7', '3.8', '3.9', "3.10"]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     runs-on: ${{ matrix.os }}-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     runs-on: ${{ matrix.os }}-latest
 
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: set up python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -49,9 +49,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v3
       with:
-        python-version: '3.8'
+        python-version: '3.9'
 
     - run: pip install -r tests/requirements-linting.txt
 
@@ -71,7 +71,7 @@ jobs:
       - name: set up python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: install
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: set up python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         python-version: '3.9'
 
     - run: pip install -r tests/requirements-linting.txt
-    - run: cat -n watchgod/watcher.py
+
     - run: make lint
     - run: make mypy
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9', "3.10"]
 
     runs-on: ${{ matrix.os }}-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       OS: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: set up python
       uses: actions/setup-python@v3
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: actions/setup-python@v3
       with:
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: set up python
         uses: actions/setup-python@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         python-version: '3.9'
 
     - run: pip install -r tests/requirements-linting.txt
-
+    - run: cat -n watchgod/watcher.py
     - run: make lint
     - run: make mypy
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /.idea/
 /env/
-/env35/
+/env*/
 *.py[cod]
 *.egg-info/
 build/

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ clean:
 	rm -f `find . -type f -name '.*~' `
 	rm -rf .cache
 	rm -rf htmlcov
+	rm -rf .pytest_cache
+	rm -rf .mypy_cache
 	rm -rf *.egg-info
 	rm -f .coverage
 	rm -f .coverage.*

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -46,6 +45,6 @@ setup(
     license='MIT',
     packages=['watchgod'],
     package_data={'watchgod': ['py.typed']},
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     zip_safe=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Intended Audience :: Developers',
         'Intended Audience :: Information Technology',
         'Intended Audience :: System Administrators',

--- a/tests/requirements-linting.txt
+++ b/tests/requirements-linting.txt
@@ -1,4 +1,4 @@
-black==20.8b1
+black==22.1.0
 flake8==3.8.4
 flake8-quotes==3.2.0
 isort==5.7.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 coverage==5.4
 pygments==2.7.4
-pytest==6.2.2
+pytest==6.2.5
 pytest-cov==2.11.1
 pytest-asyncio==0.14.0
 pytest-mock==3.5.1

--- a/watchgod/watcher.py
+++ b/watchgod/watcher.py
@@ -61,16 +61,15 @@ class AllWatcher:
                     if self.should_watch_dir(entry):
                         self._walk_dir(entry.path, changes, new_files)
                 elif self.should_watch_file(entry):
-                        self._watch_file(entry.path, changes, new_files, entry.stat())
-            except FileNotFoundError as e:
+                    self._watch_file(entry.path, changes, new_files, entry.stat())
+            except FileNotFoundError:
                 # sometimes we can't find the file. If it was deleted since
                 # `entry` was allocated, then it doesn't matter and can be
                 # ignored.  It might also be a bad symlink, in which case we
                 # should silently skip it - users don't want to constantly spam
-                # warnings, esp if they can't remove the symlink (eg from a
+                # warnings, esp if they can't remove the symlink (e.g. from a
                 # node_modules directory).
                 pass
-
 
     def check(self) -> Set['FileChange']:
         changes: Set['FileChange'] = set()


### PR DESCRIPTION
- Bumps pytest to 6.2.5, which added support for 3.10. Relevant [PR](https://github.com/pytest-dev/pytest/pull/8494) and [tag/release](https://github.com/pytest-dev/pytest/releases/tag/6.2.5).
- Bumps setup-python action in `ci.yml` workflow from v1 to v2. 3.10 is not available in v1 of the action; relevant [action run](https://github.com/joshuadavidthomas/watchgod/actions/runs/1312531475).

[Passing tests](https://github.com/joshuadavidthomas/watchgod/actions)